### PR TITLE
add -lm flag to runtime issue

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -3,7 +3,7 @@ package tokenizers
 // TODO packaging: how do we build the rust lib for distribution?
 
 /*
-#cgo LDFLAGS: ${SRCDIR}/libtokenizers.a -ldl -lstdc++
+#cgo LDFLAGS: ${SRCDIR}/libtokenizers.a -ldl -lm -lstdc++
 #include <stdlib.h>
 #include "tokenizers.h"
 */


### PR DESCRIPTION
Adding the -lm flag prevents libc incompatibility issues.

```bash
$ go run example/main.go 
# command-line-arguments
/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /home/cmichaud/github.com/daulet/tokenizers/libtokenizers.a(tokenizers-00debc4cfaeea180.tokenizers.dd41142f88f0a814-cgu.7.rcgu.o): undefined reference to symbol 'exp@@GLIBC_2.29'
/usr/bin/ld: /usr/lib/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```