### PR TITLE
libtokenizers.a path should not depend on build source directory

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -3,7 +3,7 @@ package tokenizers
 // TODO packaging: how do we build the rust lib for distribution?
 
 /*
-#cgo LDFLAGS: ${SRCDIR}/libtokenizers.a -ldl -lstdc++
+#cgo LDFLAGS: libtokenizers.a -ldl -lstdc++
 #include <stdlib.h>
 #include "tokenizers.h"
 */


### PR DESCRIPTION
By relatively locating the library, one can just drop the pre-built library in their own project to make it work.