### PR TITLE
feat: FromPretrained to load tokenizer directly from HF

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Go bindings for the [HuggingFace Tokenizers](https://github.com/huggingface/toke
 
 ## Installation
 
-`make build` to build `libtokenizers.a` that you need to run your application that uses bindings. In addition, you need to inform the linker where to find that static library: `go run -ldflags="-extldflags '-L./path/to/libtokenizers.a'" .` or just add it to the `CGO_LDFLAGS` environment variable: `CGO_LDFLAGS="-L./path/to/libtokenizers.a"` to avoid specifying it every time.
+`make build` to build `libtokenizers.a` that you need to run your application that uses bindings. In addition, you need to inform the linker where to find that static library: `go run -ldflags="-extldflags '-L./path/to/libtokenizers-directory' -ltokenizers'" .` or just add it to the `CGO_LDFLAGS` environment variable: `CGO_LDFLAGS="-L./path/to/libtokenizers-directory" -ltokenizers` to avoid specifying it every time.
 
 ### Using pre-built binaries
 
@@ -31,6 +31,20 @@ if err != nil {
 defer tk.Close()
 ```
 
+Load a tokenizer from Huggingface:
+
+```go
+import "github.com/daulet/tokenizers"
+
+tokenizerPath := "../huggingface-tokenizers/google-bert/bert-base-uncased"
+tk, err := tokenizers.LoadTokenizerFromHuggingFace("google-bert/bert-base-uncased", &tokenizerPath, nil)
+if err != nil {
+    return err
+}
+// release native resources
+defer tk.Close()
+```
+
 Encode text and decode tokens:
 
 ```go
@@ -42,6 +56,34 @@ fmt.Println(tk.Encode("brown fox jumps over the lazy dog", true))
 // [101 2829 4419 14523 2058 1996 13971 3899 102] [[CLS] brown fox jumps over the lazy dog [SEP]]
 fmt.Println(tk.Decode([]uint32{2829, 4419, 14523, 2058, 1996, 13971, 3899}, true))
 // brown fox jumps over the lazy dog
+```
+
+Encode text with options:
+
+```go
+var encodeOptions []tokenizers.EncodeOption
+encodeOptions = append(encodeOptions, tokenizers.WithReturnTypeIDs())
+encodeOptions = append(encodeOptions, tokenizers.WithReturnAttentionMask())
+encodeOptions = append(encodeOptions, tokenizers.WithReturnTokens())
+encodeOptions = append(encodeOptions, tokenizers.WithReturnOffsets())
+encodeOptions = append(encodeOptions, tokenizers.WithReturnSpecialTokensMask())
+
+// Or just basically
+// encodeOptions = append(encodeOptions, tokenizers.WithReturnAllAttributes())
+
+encodingResponse := tk.EncodeWithOptions("brown fox jumps over the lazy dog", false, encodeOptions...)
+fmt.Println(encodingResponse.IDs)
+// [2829 4419 14523 2058 1996 13971 3899]
+fmt.Println(encodingResponse.TypeIDs)
+// [0 0 0 0 0 0 0]
+fmt.Println(encodingResponse.SpecialTokensMask)
+// [0 0 0 0 0 0 0]
+fmt.Println(encodingResponse.AttentionMask)
+// [1 1 1 1 1 1 1]
+fmt.Println(encodingResponse.Tokens)
+// [brown fox jumps over the lazy dog]
+fmt.Println(encodingResponse.Offsets)
+// [[0 5] [6 9] [10 15] [16 20] [21 24] [25 29] [30 33]]
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Go bindings for the [HuggingFace Tokenizers](https://github.com/huggingface/toke
 
 ## Installation
 
-`make build` to build `libtokenizers.a` that you need to run your application that uses bindings. In addition, you need to inform the linker where to find that static library: `go run -ldflags="-extldflags '-L./path/to/libtokenizers-directory' -ltokenizers'" .` or just add it to the `CGO_LDFLAGS` environment variable: `CGO_LDFLAGS="-L./path/to/libtokenizers-directory" -ltokenizers` to avoid specifying it every time.
+`make build` to build `libtokenizers.a` that you need to run your application that uses bindings. In addition, you need to inform the linker where to find that static library: `go run -ldflags="-extldflags '-L./path/to/libtokenizers/directory'" .` or just add it to the `CGO_LDFLAGS` environment variable: `CGO_LDFLAGS="-L./path/to/libtokenizers/directory"` to avoid specifying it every time.
 
 ### Using pre-built binaries
 

--- a/example/main.go
+++ b/example/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/daulet/tokenizers"
 )
 
@@ -13,6 +12,7 @@ func main() {
 	}
 	// release native resources
 	defer tk.Close()
+
 	fmt.Println("Vocab size:", tk.VocabSize())
 	// Vocab size: 30522
 	fmt.Println(tk.Encode("brown fox jumps over the lazy dog", false))
@@ -21,4 +21,50 @@ func main() {
 	// [101 2829 4419 14523 2058 1996 13971 3899 102] [[CLS] brown fox jumps over the lazy dog [SEP]]
 	fmt.Println(tk.Decode([]uint32{2829, 4419, 14523, 2058, 1996, 13971, 3899}, true))
 	// brown fox jumps over the lazy dog
+
+	var encodeOptions []tokenizers.EncodeOption
+	encodeOptions = append(encodeOptions, tokenizers.WithReturnTypeIDs())
+	encodeOptions = append(encodeOptions, tokenizers.WithReturnAttentionMask())
+	encodeOptions = append(encodeOptions, tokenizers.WithReturnTokens())
+	encodeOptions = append(encodeOptions, tokenizers.WithReturnOffsets())
+	encodeOptions = append(encodeOptions, tokenizers.WithReturnSpecialTokensMask())
+
+	// Or just basically
+	// encodeOptions = append(encodeOptions, tokenizers.WithReturnAllAttributes())
+
+	encodingResponse := tk.EncodeWithOptions("brown fox jumps over the lazy dog", true, encodeOptions...)
+	fmt.Println(encodingResponse.IDs)
+	// [2829 4419 14523 2058 1996 13971 3899]
+	fmt.Println(encodingResponse.TypeIDs)
+	// [0 0 0 0 0 0 0]
+	fmt.Println(encodingResponse.SpecialTokensMask)
+	// [0 0 0 0 0 0 0]
+	fmt.Println(encodingResponse.AttentionMask)
+	// [1 1 1 1 1 1 1]
+	fmt.Println(encodingResponse.Tokens)
+	// [brown fox jumps over the lazy dog]
+	fmt.Println(encodingResponse.Offsets)
+	// [[0 5] [6 9] [10 15] [16 20] [21 24] [25 29] [30 33]]
+
+	tokenizerPath := "../huggingface-tokenizers/google-bert/bert-base-uncased"
+	tkFromHf, errHf := tokenizers.LoadTokenizerFromHuggingFace("google-bert/bert-base-uncased", &tokenizerPath, nil)
+	if errHf != nil {
+		panic(errHf)
+	}
+	// release native resources
+	defer tkFromHf.Close()
+
+	encodingResponseHf := tkFromHf.EncodeWithOptions("brown fox jumps over the lazy dog", true, encodeOptions...)
+	fmt.Println(encodingResponseHf.IDs)
+	// [101 2829 4419 14523 2058 1996 13971 3899 102]
+	fmt.Println(encodingResponseHf.TypeIDs)
+	// [0 0 0 0 0 0 0 0 0]
+	fmt.Println(encodingResponseHf.SpecialTokensMask)
+	// [1 0 0 0 0 0 0 0 1]
+	fmt.Println(encodingResponseHf.AttentionMask)
+	// [1 1 1 1 1 1 1 1 1]
+	fmt.Println(encodingResponseHf.Tokens)
+	// [[CLS] brown fox jumps over the lazy dog [SEP]]
+	fmt.Println(encodingResponseHf.Offsets)
+	// [[0 0] [0 5] [6 9] [10 15] [16 20] [21 24] [25 29] [30 33] [0 0]]
 }

--- a/example/main.go
+++ b/example/main.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/daulet/tokenizers"
 )
 
-func main() {
+func simple() error {
 	tk, err := tokenizers.FromFile("../test/data/bert-base-uncased.json")
 	if err != nil {
-		panic(err)
+		return err
 	}
 	// release native resources
 	defer tk.Close()
@@ -21,50 +23,60 @@ func main() {
 	// [101 2829 4419 14523 2058 1996 13971 3899 102] [[CLS] brown fox jumps over the lazy dog [SEP]]
 	fmt.Println(tk.Decode([]uint32{2829, 4419, 14523, 2058, 1996, 13971, 3899}, true))
 	// brown fox jumps over the lazy dog
+	return nil
+}
 
-	var encodeOptions []tokenizers.EncodeOption
-	encodeOptions = append(encodeOptions, tokenizers.WithReturnTypeIDs())
-	encodeOptions = append(encodeOptions, tokenizers.WithReturnAttentionMask())
-	encodeOptions = append(encodeOptions, tokenizers.WithReturnTokens())
-	encodeOptions = append(encodeOptions, tokenizers.WithReturnOffsets())
-	encodeOptions = append(encodeOptions, tokenizers.WithReturnSpecialTokensMask())
-
-	// Or just basically
-	// encodeOptions = append(encodeOptions, tokenizers.WithReturnAllAttributes())
-
-	encodingResponse := tk.EncodeWithOptions("brown fox jumps over the lazy dog", true, encodeOptions...)
-	fmt.Println(encodingResponse.IDs)
-	// [2829 4419 14523 2058 1996 13971 3899]
-	fmt.Println(encodingResponse.TypeIDs)
-	// [0 0 0 0 0 0 0]
-	fmt.Println(encodingResponse.SpecialTokensMask)
-	// [0 0 0 0 0 0 0]
-	fmt.Println(encodingResponse.AttentionMask)
-	// [1 1 1 1 1 1 1]
-	fmt.Println(encodingResponse.Tokens)
-	// [brown fox jumps over the lazy dog]
-	fmt.Println(encodingResponse.Offsets)
-	// [[0 5] [6 9] [10 15] [16 20] [21 24] [25 29] [30 33]]
-
-	tokenizerPath := "../huggingface-tokenizers/google-bert/bert-base-uncased"
-	tkFromHf, errHf := tokenizers.LoadTokenizerFromHuggingFace("google-bert/bert-base-uncased", &tokenizerPath, nil)
-	if errHf != nil {
-		panic(errHf)
+func advanced() error {
+	// Load tokenizer from local config file
+	tk, err := tokenizers.FromFile("../test/data/bert-base-uncased.json")
+	if err != nil {
+		return err
 	}
-	// release native resources
+	defer tk.Close()
+
+	// Load pretrained tokenizer from HuggingFace
+	tokenizerPath := "./.cache/tokenizers/google-bert/bert-base-uncased"
+	tkFromHf, err := tokenizers.FromPretrained("google-bert/bert-base-uncased", &tokenizerPath, nil)
+	if err != nil {
+		return err
+	}
 	defer tkFromHf.Close()
 
-	encodingResponseHf := tkFromHf.EncodeWithOptions("brown fox jumps over the lazy dog", true, encodeOptions...)
-	fmt.Println(encodingResponseHf.IDs)
-	// [101 2829 4419 14523 2058 1996 13971 3899 102]
-	fmt.Println(encodingResponseHf.TypeIDs)
-	// [0 0 0 0 0 0 0 0 0]
-	fmt.Println(encodingResponseHf.SpecialTokensMask)
-	// [1 0 0 0 0 0 0 0 1]
-	fmt.Println(encodingResponseHf.AttentionMask)
-	// [1 1 1 1 1 1 1 1 1]
-	fmt.Println(encodingResponseHf.Tokens)
-	// [[CLS] brown fox jumps over the lazy dog [SEP]]
-	fmt.Println(encodingResponseHf.Offsets)
-	// [[0 0] [0 5] [6 9] [10 15] [16 20] [21 24] [25 29] [30 33] [0 0]]
+	// Encode with specific options
+	encodeOptions := []tokenizers.EncodeOption{
+		tokenizers.WithReturnTypeIDs(),
+		tokenizers.WithReturnAttentionMask(),
+		tokenizers.WithReturnTokens(),
+		tokenizers.WithReturnOffsets(),
+		tokenizers.WithReturnSpecialTokensMask(),
+	}
+	// Or simply:
+	// encodeOptions = append(encodeOptions, tokenizers.WithReturnAllAttributes())
+
+	// regardless of how the tokenizer was initialized, the output is the same
+	for _, tkzr := range []*tokenizers.Tokenizer{tk, tkFromHf} {
+		encodingResponse := tkzr.EncodeWithOptions("brown fox jumps over the lazy dog", true, encodeOptions...)
+		fmt.Println(encodingResponse.IDs)
+		// [101 2829 4419 14523 2058 1996 13971 3899 102]
+		fmt.Println(encodingResponse.TypeIDs)
+		// [0 0 0 0 0 0 0 0 0]
+		fmt.Println(encodingResponse.SpecialTokensMask)
+		// [1 0 0 0 0 0 0 0 1]
+		fmt.Println(encodingResponse.AttentionMask)
+		// [1 1 1 1 1 1 1 1 1]
+		fmt.Println(encodingResponse.Tokens)
+		// [[CLS] brown fox jumps over the lazy dog [SEP]]
+		fmt.Println(encodingResponse.Offsets)
+		// [[0 0] [0 5] [6 9] [10 15] [16 20] [21 24] [25 29] [30 33] [0 0]]
+	}
+	return nil
+}
+
+func main() {
+	if err := simple(); err != nil {
+		log.Fatal(err)
+	}
+	if err := advanced(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -35,8 +35,7 @@ func advanced() error {
 	defer tk.Close()
 
 	// Load pretrained tokenizer from HuggingFace
-	tokenizerPath := "./.cache/tokenizers/google-bert/bert-base-uncased"
-	tkFromHf, err := tokenizers.FromPretrained("google-bert/bert-base-uncased", &tokenizerPath, nil)
+	tkFromHf, err := tokenizers.FromPretrained("google-bert/bert-base-uncased", tokenizers.WithCacheDir("./.cache/tokenizers"))
 	if err != nil {
 		return err
 	}

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -97,13 +97,13 @@ func FromFile(path string) (*Tokenizer, error) {
 	return &Tokenizer{tokenizer: tokenizer}, nil
 }
 
-// LoadTokenizerFromHuggingFace downloads necessary files and initializes the tokenizer.
+// FromPretrained downloads necessary files and initializes the tokenizer.
 // Parameters:
 //   - modelID: The Hugging Face model identifier (e.g., "bert-base-uncased").
 //   - destination: Optional. If provided and not nil, files will be downloaded to this folder.
 //     If nil, a temporary directory will be used.
 //   - authToken: Optional. If provided and not nil, it will be used to authenticate requests.
-func LoadTokenizerFromHuggingFace(modelID string, destination, authToken *string) (*Tokenizer, error) {
+func FromPretrained(modelID string, destination, authToken *string) (*Tokenizer, error) {
 	if strings.TrimSpace(modelID) == "" {
 		return nil, fmt.Errorf("modelID cannot be empty")
 	}
@@ -179,7 +179,6 @@ func LoadTokenizerFromHuggingFace(modelID string, destination, authToken *string
 func downloadFile(url, destination string, authToken *string) error {
 	// Check if the file already exists
 	if _, err := os.Stat(destination); err == nil {
-		fmt.Printf("File %s already exists. Skipping download.\n", destination)
 		return nil
 	}
 

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -137,7 +137,7 @@ func FromPretrained(modelID string, opts ...TokenizerConfigOption) (*Tokenizer, 
 	// Determine the download directory
 	var downloadDir string
 	if cfg.cacheDir != nil {
-		downloadDir = *cfg.cacheDir
+		downloadDir = fmt.Sprintf("%s/%s", *cfg.cacheDir, modelID)
 		// Create the destination directory if it doesn't exist
 		err := os.MkdirAll(downloadDir, os.ModePerm)
 		if err != nil {

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -182,13 +182,6 @@ func downloadFile(url, destination string, authToken *string) error {
 		return nil
 	}
 
-	// Create the destination file
-	out, err := os.Create(destination)
-	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", destination, err)
-	}
-	defer out.Close()
-
 	// Create a new HTTP request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -196,13 +189,11 @@ func downloadFile(url, destination string, authToken *string) error {
 	}
 
 	// If authToken is provided, set the Authorization header
-	if authToken != nil && *authToken != "" {
+	if authToken != nil {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *authToken))
 	}
 
-	// Perform the HTTP request
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to download from %s: %w", url, err)
 	}
@@ -212,6 +203,13 @@ func downloadFile(url, destination string, authToken *string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to download from %s: status code %d", url, resp.StatusCode)
 	}
+
+	// Create the destination file
+	out, err := os.Create(destination)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", destination, err)
+	}
+	defer out.Close()
 
 	// Write the response body to the file
 	_, err = io.Copy(out, resp.Body)

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -4,11 +4,8 @@ import (
 	_ "embed"
 	"github.com/daulet/tokenizers"
 	"math/rand"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,23 +14,6 @@ import (
 
 //go:embed test/data/sentence-transformers-labse.json
 var embeddedBytes []byte
-
-type mockTransport struct {
-	server  *httptest.Server
-	modelID string
-}
-
-func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.URL.Scheme = "http"
-	req.URL.Host = strings.TrimPrefix(t.server.URL, "http://")
-
-	parts := strings.Split(req.URL.Path, "/")
-	if len(parts) > 2 {
-		req.URL.Path = "/" + t.modelID + "/resolve/main/" + parts[len(parts)-1]
-	}
-
-	return t.server.Client().Transport.RoundTrip(req)
-}
 
 // TODO test for leaks
 
@@ -494,249 +474,120 @@ func BenchmarkDecodeNTokens(b *testing.B) {
 	assert.Greater(b, len(text), b.N)
 }
 
-func mockHuggingFaceServer(t *testing.T) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := strings.TrimPrefix(r.URL.Path, "/")
-		parts := strings.Split(path, "/")
-
-		if len(parts) < 4 {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		fileName := parts[len(parts)-1]
-
-		// Check authentication for private models
-		if strings.HasPrefix(path, "private/") {
-			authHeader := r.Header.Get("Authorization")
-			if !strings.Contains(authHeader, "test-token") {
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-		}
-
-		// For nonexistent model, only return 404 for tokenizer.json
-		if strings.Contains(path, "nonexistent") {
-			if fileName == "tokenizer.json" {
-				w.WriteHeader(http.StatusNotFound)
-				return
-			}
-			// Return empty response for optional files
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("{}"))
-			return
-		}
-
-		// Handle regular file requests
-		switch fileName {
-		case "tokenizer.json":
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
-				"type": "mock_tokenizer",
-				"vocab_size": 1000,
-				"model_max_length": 512
-			}`))
-		case "vocab.txt":
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("[PAD]\n[UNK]\ntest\ntoken"))
-		case "special_tokens_map.json":
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
-				"pad_token": "[PAD]",
-				"unk_token": "[UNK]"
-			}`))
-		default:
-			// Return empty response for other optional files
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("{}"))
-		}
-	}))
-}
-
 func TestFromPretrained(t *testing.T) {
-	server := mockHuggingFaceServer(t)
-	defer server.Close()
-
 	tests := []struct {
-		name      string
-		modelID   string
-		setupOpts func() []tokenizers.TokenizerConfigOption
-		wantError bool
-		checkDir  func(t *testing.T, dir string) // Add function to verify directory
+		name          string
+		modelID       string
+		setupOpts     func(t *testing.T) ([]tokenizers.TokenizerConfigOption, string)
+		expectedError bool
+		expectedToken bool
+		skipCache     bool
 	}{
 		{
-			name:    "valid public model with cache dir",
-			modelID: "bert-base-uncased",
-			setupOpts: func() []tokenizers.TokenizerConfigOption {
+			name:          "valid public model with cache dir",
+			modelID:       "bert-base-uncased",
+			expectedToken: true,
+			setupOpts: func(t *testing.T) ([]tokenizers.TokenizerConfigOption, string) {
 				tmpDir := t.TempDir()
 				return []tokenizers.TokenizerConfigOption{
 					tokenizers.WithCacheDir(tmpDir),
-				}
+				}, tmpDir
 			},
-			wantError: false,
 		},
 		{
-			name:    "valid public model without cache dir",
-			modelID: "bert-base-uncased",
-			setupOpts: func() []tokenizers.TokenizerConfigOption {
-				return nil // No cache dir specified
+			name:          "valid public model without cache dir",
+			modelID:       "bert-base-uncased",
+			expectedToken: true,
+			setupOpts: func(t *testing.T) ([]tokenizers.TokenizerConfigOption, string) {
+				return nil, ""
 			},
-			wantError: false,
+			skipCache: true,
 		},
 		{
-			name:    "private model with auth token and cache dir",
-			modelID: "private/model",
-			setupOpts: func() []tokenizers.TokenizerConfigOption {
+			name:          "private model with valid auth token",
+			modelID:       "bert-base-uncased",
+			expectedToken: true,
+			setupOpts: func(t *testing.T) ([]tokenizers.TokenizerConfigOption, string) {
 				tmpDir := t.TempDir()
 				return []tokenizers.TokenizerConfigOption{
 					tokenizers.WithCacheDir(tmpDir),
 					tokenizers.WithAuthToken("test-token"),
-				}
-			},
-			wantError: false,
-			checkDir: func(t *testing.T, dir string) {
-				path := filepath.Join(dir, "private", "model", "tokenizer.json")
-				if _, err := os.Stat(path); os.IsNotExist(err) {
-					t.Errorf("expected tokenizer.json to exist in cache dir")
-				}
+				}, tmpDir
 			},
 		},
 		{
-			name:    "private model with auth token without cache dir",
-			modelID: "private/model",
-			setupOpts: func() []tokenizers.TokenizerConfigOption {
-				return []tokenizers.TokenizerConfigOption{
-					tokenizers.WithAuthToken("test-token"),
-				}
-			},
-			wantError: false,
-			checkDir: func(t *testing.T, dir string) {
-				if !strings.Contains(dir, "huggingface-tokenizer-") {
-					t.Errorf("expected temp directory name to contain 'huggingface-tokenizer-', got %s", dir)
-				}
-			},
-		},
-		{
-			name:      "empty model ID",
-			modelID:   "",
-			setupOpts: func() []tokenizers.TokenizerConfigOption { return nil },
-			wantError: true,
-			checkDir:  nil, // No directory check needed for error case
-		},
-		{
-			name:    "nonexistent model",
-			modelID: "nonexistent/model",
-			setupOpts: func() []tokenizers.TokenizerConfigOption {
+			name:          "private model with invalid auth token",
+			modelID:       "private-model",
+			expectedError: true,
+			setupOpts: func(t *testing.T) ([]tokenizers.TokenizerConfigOption, string) {
 				tmpDir := t.TempDir()
 				return []tokenizers.TokenizerConfigOption{
 					tokenizers.WithCacheDir(tmpDir),
-				}
+					tokenizers.WithAuthToken("invalid-token"),
+				}, tmpDir
 			},
-			wantError: true,
-			checkDir:  nil, // No directory check needed for error case
+			skipCache: true,
+		},
+		{
+			name:          "empty model ID",
+			modelID:       "",
+			expectedError: true,
+			setupOpts: func(t *testing.T) ([]tokenizers.TokenizerConfigOption, string) {
+				return nil, ""
+			},
+			skipCache: true,
+		},
+		{
+			name:          "nonexistent model",
+			modelID:       "nonexistent/model",
+			expectedError: true,
+			setupOpts: func(t *testing.T) ([]tokenizers.TokenizerConfigOption, string) {
+				tmpDir := t.TempDir()
+				return []tokenizers.TokenizerConfigOption{
+					tokenizers.WithCacheDir(tmpDir),
+				}, tmpDir
+			},
+			skipCache: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			origTransport := http.DefaultClient.Transport
-			http.DefaultClient.Transport = &mockTransport{
-				server:  server,
-				modelID: tt.modelID,
+			opts, cacheDir := tt.setupOpts(t)
+			tokenizer, err := tokenizers.FromPretrained(tt.modelID, opts...)
+
+			if tt.expectedError && err == nil {
+				t.Fatalf("expected error for case %s, got nil", tt.name)
 			}
-			defer func() { http.DefaultClient.Transport = origTransport }()
-
-			tokenizer, err := tokenizers.FromPretrained(tt.modelID, tt.setupOpts()...)
-
-			if tt.wantError {
-				if err == nil {
-					t.Error("expected error, got nil")
-				}
+			if !tt.expectedError && err != nil {
+				t.Fatalf("unexpected error for case %s: %v", tt.name, err)
+			}
+			if !tt.expectedToken && tokenizer != nil {
+				t.Fatalf("expected nil tokenizer for case %s, got non-nil", tt.name)
+			}
+			if tt.expectedToken && tokenizer == nil {
+				t.Fatalf("expected non-nil tokenizer for case %s", tt.name)
+			}
+			if tt.expectedError {
 				return
 			}
-
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
+			if !tt.skipCache && cacheDir != "" {
+				validateCache(t, cacheDir, tt.modelID)
 			}
-
-			if tokenizer == nil {
-				t.Error("expected tokenizer, got nil")
-				return
-			}
-
 			if err := tokenizer.Close(); err != nil {
-				t.Errorf("error closing tokenizer: %v", err)
+				t.Fatalf("error closing tokenizer: %v", err)
 			}
 		})
 	}
 }
 
-func TestConfigOptions(t *testing.T) {
-	server := mockHuggingFaceServer(t)
-	defer server.Close()
-
-	t.Run("WithCacheDir", func(t *testing.T) {
-		tmpDir := t.TempDir()
-
-		origTransport := http.DefaultClient.Transport
-		http.DefaultClient.Transport = &mockTransport{
-			server:  server,
-			modelID: "bert-base-uncased",
+func validateCache(t *testing.T, dir string, modelID string) {
+	t.Helper()
+	files := []string{"tokenizer.json", "vocab.txt"}
+	for _, file := range files {
+		path := filepath.Join(dir, modelID, file)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Fatalf("expected file %s to exist in cache for model %s", file, modelID)
 		}
-		defer func() { http.DefaultClient.Transport = origTransport }()
-
-		tokenizer, err := tokenizers.FromPretrained(
-			"bert-base-uncased",
-			tokenizers.WithCacheDir(tmpDir),
-		)
-
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-			return
-		}
-		defer tokenizer.Close()
-
-		files := []string{"tokenizer.json", "vocab.txt", "special_tokens_map.json"}
-		for _, file := range files {
-			path := filepath.Join(tmpDir, "bert-base-uncased", file)
-			if _, err := os.Stat(path); os.IsNotExist(err) {
-				t.Errorf("expected file %s to exist", file)
-			}
-		}
-	})
-
-	t.Run("WithAuthToken", func(t *testing.T) {
-		origTransport := http.DefaultClient.Transport
-		http.DefaultClient.Transport = &mockTransport{
-			server:  server,
-			modelID: "private/model",
-		}
-		defer func() { http.DefaultClient.Transport = origTransport }()
-
-		tokenizer, err := tokenizers.FromPretrained(
-			"private/model",
-			tokenizers.WithAuthToken("test-token"),
-			tokenizers.WithCacheDir(t.TempDir()),
-		)
-
-		if err != nil {
-			t.Errorf("unexpected error with valid auth token: %v", err)
-			return
-		}
-		if tokenizer != nil {
-			tokenizer.Close()
-		}
-
-		tokenizer, err = tokenizers.FromPretrained(
-			"private/model",
-			tokenizers.WithAuthToken("invalid-token"),
-			tokenizers.WithCacheDir(t.TempDir()),
-		)
-
-		if err == nil {
-			t.Error("expected error with invalid auth token, got nil")
-			tokenizer.Close()
-		}
-	})
+	}
 }


### PR DESCRIPTION
| Benchmark            | benchmarks/eafe2ce1db50dcd78b3b7157bf2c669109f4e322.txt | benchmarks/867b67eeade51e570d5150cebddab679b855e885.txt | Change               |
|----------------------|--------------------------------------------------------|--------------------------------------------------------|----------------------|
| **sec/op**           |                                                        |                                                        |                      |
| EncodeNTimes-10      | 12.75µ ± 2%                                            | 12.60µ ± 1%                                            | -1.18% (p=0.015 n=6) |
| EncodeNChars-10      | 0.3629n ± 19%                                          | 0.3589n ± 8%                                           | ~ (p=1.000 n=6)      |
| DecodeNTimes-10      | 4.433µ ± 1%                                            | 4.481µ ± 1%                                            | +1.08% (p=0.011 n=6) |
| DecodeNTokens-10     | 660.5n ± 2%                                            | 662.0n ± 5%                                            | ~ (p=0.485 n=6)      |
| Geomean              | 341.2n                                                 | 340.3n                                                 | -0.25%               |

| Benchmark            | benchmarks/eafe2ce1db50dcd78b3b7157bf2c669109f4e322.txt | benchmarks/867b67eeade51e570d5150cebddab679b855e885.txt | Change               |
|----------------------|--------------------------------------------------------|--------------------------------------------------------|----------------------|
| **B/op**             |                                                        |                                                        |                      |
| EncodeNTimes-10      | 232.0 ± 0%                                             | 232.0 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| EncodeNChars-10      | 0.000 ± 0%                                             | 0.000 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| DecodeNTimes-10      | 96.00 ± 0%                                             | 96.00 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| DecodeNTokens-10     | 7.000 ± 0%                                             | 7.000 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| Geomean              |                                                        |                                                        | +0.00%²              |

| Benchmark            | benchmarks/eafe2ce1db50dcd78b3b7157bf2c669109f4e322.txt | benchmarks/867b67eeade51e570d5150cebddab679b855e885.txt | Change               |
|----------------------|--------------------------------------------------------|--------------------------------------------------------|----------------------|
| **allocs/op**        |                                                        |                                                        |                      |
| EncodeNTimes-10      | 12.00 ± 0%                                             | 12.00 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| EncodeNChars-10      | 0.000 ± 0%                                             | 0.000 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| DecodeNTimes-10      | 3.000 ± 0%                                             | 3.000 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| DecodeNTokens-10     | 0.000 ± 0%                                             | 0.000 ± 0%                                             | ~ (p=1.000 n=6)¹     |
| Geomean              |                                                        |                                                        | +0.00%²              |

¹ All samples are equal  
² Summaries must be >0 to compute geomean
